### PR TITLE
generating Linux logs if RA is installed via flatpak

### DIFF
--- a/docs/guides/generating-retroarch-logs.md
+++ b/docs/guides/generating-retroarch-logs.md
@@ -22,11 +22,17 @@ The answer to this dilemma involves "logs", which RetroArch and other libretro s
 ### Generating Logs in Linux
 
 #### RetroArch logs
+##### If installed via **apt**
 1. Open a terminal.
-2. Navigate to the RetroArch folder with the `cd` command.
-3. Start RetroArch in 'verbose' mode with this command:<br />
- `retroarch -v --log-file retroarch.log` or `retroarch -v >> retroarch.log 2>&1`
-4. Once you exit RetroArch, a file called `retroarch.log` should be stored in the folder.
+2. Start RetroArch in 'verbose' mode with this command:<br />
+ `retroarch -v --log-file retroarch.log` or `retroarch -v >> ~/retroarch.log 2>&1`
+3. Once you exit RetroArch, a file called `retroarch.log` should be stored in the file retroarch.log in your home directory.
+
+##### If installed via **flatpak**
+1. Open a terminal.
+2. Start RetroArch in 'verbose' mode with this command:<br />
+ `/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=retroarch org.libretro.RetroArch -v --log-file ~/retroarch.log`
+3. Once you exit RetroArch, a file called `retroarch.log` should be stored in the file retroarch.log in your home directory.
 
 #### Graphic card logs
 `lspci -nnk | grep -A 3 VGA` will give information about your graphic card.


### PR DESCRIPTION
Moreover, I removed the "cd to the main RA directory" as it is not really necessary and might be difficult for some users to do. Plus it might often require root privileges. In the way I documented, logs are generated in the homedir of the user and there is one less step to be done.